### PR TITLE
fix git repo name in all our 3 npm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ but we instead use normal dependencies.
 Indeed, in our specific case, having normal dependencies reduce the maintenance burden
 of specifying all the needed peer dependencies when adding a specific ESLint configuration.
 
-That's means that we simply need to depend on the right config project to run ESLint.
+That means that we simply need to depend on the right config project to run ESLint.
 
 Of course, it could causes problem eventually, but we are ready to live with it.
 

--- a/modules/base/package.json
+++ b/modules/base/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/breathelife/eslint-config-breathelife"
+    "url": "https://github.com/getbreathelife/eslint-config-breathelife"
   },
   "keywords": [
     "eslint",
@@ -22,9 +22,9 @@
   "author": "Breathe Life",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/breathelife/eslint-config-breathelife/issues"
+    "url": "https://github.com/getbreathelife/eslint-config-breathelife/issues"
   },
-  "homepage": "https://github.com/breathelife/eslint-config-breathelife",
+  "homepage": "https://github.com/getbreathelife/eslint-config-breathelife",
   "engines": {
     "node": ">= 4"
   },

--- a/modules/node/README.md
+++ b/modules/node/README.md
@@ -18,7 +18,7 @@ Indeed, in our specific case, having normal dependencies reduce the maintenance 
 of specifying all the needed peer dependencies when adding a specific ESLint
 configuration to a project.
 
-That's means that we simply need to depend on the right config project (mobile, node or
+That means that we simply need to depend on the right config project (mobile, node or
 web) to enable and configure ESLint.
 
 Of course, potential conflict problems could arise eventually, but we are ready to

--- a/modules/node/package.json
+++ b/modules/node/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/breathelife/eslint-config-breathelife"
+    "url": "https://github.com/getbreathelife/eslint-config-breathelife"
   },
   "keywords": [
     "eslint",
@@ -23,9 +23,9 @@
   "author": "Breathe Life",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/breathelife/eslint-config-breathelife/issues"
+    "url": "https://github.com/getbreathelife/eslint-config-breathelife/issues"
   },
-  "homepage": "https://github.com/breathelife/eslint-config-breathelife",
+  "homepage": "https://github.com/getbreathelife/eslint-config-breathelife",
   "engines": {
     "node": ">= 4"
   },

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -18,7 +18,7 @@ Indeed, in our specific case, having normal dependencies reduce the maintenance 
 of specifying all the needed peer dependencies when adding a specific ESLint
 configuration to a project.
 
-That's means that we simply need to depend on the config project to enable and configure ESLint.
+That means that we simply need to depend on the config project to enable and configure ESLint.
 
 Of course, potential conflict problems could arise eventually, but we are ready to live with it.
 

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/breathelife/eslint-config-breathelife"
+    "url": "https://github.com/getbreathelife/eslint-config-breathelife"
   },
   "keywords": [
     "eslint",
@@ -18,9 +18,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/breathelife/eslint-config-breathelife/issues"
+    "url": "https://github.com/getbreathelife/eslint-config-breathelife/issues"
   },
-  "homepage": "https://github.com/breathelife/eslint-config-breathelife",
+  "homepage": "https://github.com/getbreathelife/eslint-config-breathelife",
   "engines": {
     "node": ">= 4"
   },


### PR DESCRIPTION
Those 3 npm packages will now have the correct git repo name shown on their npm page's sidebar:

* https://www.npmjs.com/package/eslint-config-breathelife-base
* https://www.npmjs.com/package/eslint-config-breathelife-web
* https://www.npmjs.com/package/eslint-config-breathelife-node

TODO:

- [ ]  publish updates to npm – not sure how to do that